### PR TITLE
Update to .NET 10.0.x and adjust documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 
 ## Libraries and Frameworks
 
-- Use .NET in version 8.0.x as basic framework.
+- Use .NET in version 10.0.x as basic framework.
 
 ## Coding Standards
 

--- a/.github/workflows/nuget-deploy.yml
+++ b/.github/workflows/nuget-deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DOTNET_VERSION: '8.0.x'
+      DOTNET_VERSION: '10.0.x'
 
     permissions:
       id-token: write


### PR DESCRIPTION
This pull request updates the project's .NET framework version from 8.0.x to 10.0.x to ensure compatibility with the latest features and improvements. The change is reflected both in the documentation and the CI workflow configuration.

.NET version upgrade:

* Updated the framework version in `.github/copilot-instructions.md` to specify .NET 10.0.x as the basic framework.
* Changed the `DOTNET_VERSION` environment variable in `.github/workflows/nuget-deploy.yml` from 8.0.x to 10.0.x to align the CI pipeline with the new framework version.